### PR TITLE
fix addon-linter issues with default study.js code

### DIFF
--- a/lib/study.js
+++ b/lib/study.js
@@ -1,6 +1,5 @@
 /** study.js **/
 const self = require("sdk/self");
-const prefSvc = require("sdk/preferences/service");
 const shield = require("shield-studies-addon-utils");
 const tabs = require('sdk/tabs');
 const { when: unload } = require("sdk/system/unload");
@@ -38,7 +37,9 @@ class OurStudy extends shield.Study {
   whenInstalled () {
     super.whenInstalled();
     // orientation, unless our branch is 'notheme'
-    if (this.variation == 'notheme') {}
+    if (this.variation == 'notheme') {
+      return
+    }
     feature.orientation(this.variation);
   }
   cleanup (reason) {


### PR DESCRIPTION
addon-linter complained about these issues the first time I tried to `grunt test` the template code.