### PR TITLE
call feature.cleanup from Study.cleanup|whenComplete

### DIFF
--- a/lib/feature.js
+++ b/lib/feature.js
@@ -12,6 +12,6 @@ exports.isEligible = function () {
   return !prefSvc.isSet(ourpref);
 };
 
-exports.reset = function () {
+exports.cleanup = function () {
   return prefSvc.reset(ourpref);
 };

--- a/lib/study.js
+++ b/lib/study.js
@@ -50,6 +50,7 @@ class OurStudy extends shield.Study {
   whenComplete () {
     // when the study is naturally complete after this.days
     super.whenComplete();  // calls survey, uninstalls
+    feature.cleanup();
   }
   whenUninstalled () {
     // user uninstall


### PR DESCRIPTION
Looking thru the howToShieldStudy doc and the addon template code indicates the shield add-on should include and call `feature.cleanup` instead of including a `feature.reset` method?

And `Study.whenComplete` should also call the `feature.cleanup` method?
