### PR TITLE
Change default guid suffix to `@shield.mozilla.org`

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Mozilla Gregg Lind <glind@mozilla.com>",
   "addon": {
     "$ABOUT": "use these variables fill the moustache templates",
-    "id": "button-icon-preference@shield-study.mozilla.com",
+    "id": "button-icon-preference@shield.mozilla.org",
     "name": "Button Icon Preference Study (Shield Study Example)",
     "minVersion": "57.0",
     "maxVersion": "*",


### PR DESCRIPTION
Updating the default guid in this template to reflect future plans for Normandy to enforce shield add-on guid suffixes as per [this PR](https://github.com/mozilla/normandy/issues/1108).

This is important for analysis i.e. properly filtering out/identifying shield add-ons in telemetry.